### PR TITLE
Add process README summarizing OctoAcme project management and linking all process docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# OctoAcme Project Management Documentation
+
+Welcome! This README provides a central starting point to understand how OctoAcme manages projects and gives you quick access to all process documentation.
+
+## Project Management Process Summary
+
+OctoAcme’s project management is guided by customer-first delivery, clear roles, iterative progress, and data-informed decisions. Each project begins with a structured initiation, using one-pagers and high-level roadmaps to secure alignment on outcomes and resources. The Project Manager drives execution and communication, while the Product Manager focuses on defining outcomes and the prioritized backlog, and Developers deliver features with quality in mind.
+
+Workflows progress from initiation and planning through execution, release, and retrospectives. Planning involves detailed backlogs, acceptance criteria, and risk assessments. Projects are managed using project boards with clear status columns. Team rhythm includes daily standups, weekly delivery syncs, and milestone reviews, ensuring transparency and adaptability throughout the lifecycle. Risks are captured early and escalated through documented paths when needed.
+
+Open communication is a core principle, with health updates, regular stakeholder syncs, and living artifacts such as risk registers and retrospective notes providing a single source of truth. Each persona maintains responsibility for communicating status and updates.
+
+Quality assurance runs throughout the project lifecycle, featuring automated tests, manual QA, CI/CD gates, and robust release checklists. Incidents prompt fast rollback and transparent communication, with learnings captured and fed back into continuous improvement cycles. This approach supports consistent, customer-driven outcomes and fosters a culture of iteration and shared ownership.
+
+## Process Documents
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](./octoacme-roles-and-personas.md)
+
+Please refer to these documents for detailed phase- or artifact-specific guidance.


### PR DESCRIPTION
This README outlines the project management processes and provides links to detailed documentation.

PR Title: Add process README summarizing OctoAcme project management and linking all process docs
Files changed: docs/README.md
Reviewer: Technoheart66
Issue: Closes #3