### PR TITLE
Improve roles & personas: add new personas, checklist, and cross-doc references

### DIFF
--- a/docs/octoacme-execution-and-tracking.md
+++ b/docs/octoacme-execution-and-tracking.md
@@ -33,6 +33,10 @@ Guidance for managing day-to-day execution and tracking progress toward project 
 - Level 2: PM escalates to Product Lead and dependent teams
 - Level 3: Sponsor-level escalation for business-impacting issues
 
+Notes on role interactions during execution:
+- DevOps Engineer: coordinates scheduled deployments, supports CI/CD stabilization, manages runbooks for post-deploy verification. For deployments that affect timelines or require special windows, PM and DevOps should coordinate to ensure alignment with release plan.
+- Customer Advocate: collects and surfaces real-world feedback post-release. When customer issues impact project priorities or require rapid fixes, Customer Advocate works with PdM and PM to re-prioritize or trigger incident response.
+
 ## Execution Checklist
 - [ ] Branching and PR conventions documented in repo
 - [ ] CI configured for tests and lint

--- a/docs/octoacme-project-management-overview.md
+++ b/docs/octoacme-project-management-overview.md
@@ -20,6 +20,16 @@ Applies to all cross-functional projects that deliver product features, services
 - QA/Testing: validate quality and acceptance criteria.
 - Stakeholders: provide inputs and approvals.
 
+## Additional / Supporting Roles
+(Recently expanded — see docs/octoacme-roles-and-personas.md for detailed definitions)
+- Business Analyst (BA)
+- DevOps Engineer
+- UX Designer
+- Executive Sponsor
+- Customer Advocate
+
+These roles often provide critical inputs, governance, or operational capabilities that complement the core delivery team. Refer to docs/octoacme-roles-and-personas.md for responsibilities and interaction patterns.
+
 ## Key Artifacts
 - Project Charter / One-pager
 - Roadmap and Release Plan
@@ -44,3 +54,4 @@ Applies to all cross-functional projects that deliver product features, services
 ## How to use these docs
 - Keep the Project Charter updated in the project repo.
 - Add process-specific docs into `.copilot/` if you want Copilot Spaces to use them as context.
+- Reference docs/roles-and-personas-checklist.md when introducing or updating a role.

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,83 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## QA / Testing
+
+(Existing QA responsibilities — validate quality and acceptance criteria)
+
+---
+
+## Stakeholders
+
+(Existing content)
+
+---
+
+## New / Expanded Personas (proposed additions)
+
+These personas reflect common but previously under-described functions that influence project outcomes. Add them to the canonical roles doc to improve clarity and accountability.
+
+### Business Analyst (BA)
+- Responsibilities:
+  - Elicit and document requirements from stakeholders and users.
+  - Map business processes and identify gaps or improvement opportunities.
+  - Translate business needs into clear user stories and acceptance criteria.
+  - Support acceptance testing and validate delivered outcomes against business scenarios.
+- Interactions:
+  - Works with PdM to refine scope and success criteria.
+  - Partners with PM and Developers during planning to ensure requirements are actionable.
+  - Engages stakeholders and Customer Advocate to validate assumptions and outcomes.
+
+### DevOps Engineer
+- Responsibilities:
+  - Design, build, and maintain CI/CD pipelines, automation, and infrastructure-as-code.
+  - Improve deployment reliability, observability, and recovery processes.
+  - Collaborate on production readiness, capacity planning, and runbooks.
+- Interactions:
+  - Works with Developers to enable smooth release processes and testing automation.
+  - Supports PM and QA with deployment schedules, rollback plans, and post-release verification.
+  - Escalates operational risks to PM and Product Lead when release or infra constraints affect timelines.
+
+### UX Designer
+- Responsibilities:
+  - Lead user research, design user flows, wireframes, and high-fidelity interfaces.
+  - Validate usability through testing and iterate designs based on feedback.
+  - Produce assets and design specifications for engineering implementation.
+- Interactions:
+  - Collaborates with PdM to ensure product decisions align with user needs.
+  - Works with Developers to clarify implementation details and acceptance criteria for UI/UX.
+  - Partners with Customer Advocate and BA for research and validation activities.
+
+### Executive Sponsor
+- Responsibilities:
+  - Provide strategic guidance and ensure alignment with broader organizational objectives.
+  - Approve budgets and major scope decisions; support escalation for business-critical issues.
+  - Champion the project at leadership forums to remove cross-organizational blockers.
+- Interactions:
+  - Engages periodically with PM and PdM for milestone reviews and major decisions.
+  - Is looped in by PM for Level-3 escalations and significant risk/constraint discussions.
+
+### Customer Advocate (User Research / Support Liaison)
+- Responsibilities:
+  - Represent customer voice across discovery and delivery phases.
+  - Collect, synthesize, and communicate user feedback to PdM and UX.
+  - Help validate user impact of proposed changes and post-release satisfaction.
+- Interactions:
+  - Works closely with PdM, UX, BA, and QA to ensure user feedback shapes priorities and acceptance.
+  - Partners with Support and Sales to surface real-world issues and trends.
+  - Participates in demos or feedback sessions where appropriate.
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
 
+---
+
+## Guidelines for adding new personas
+- Define a short Role Summary (1–2 sentences).
+- List clear Responsibilities (3–6 bullets).
+- State Typical Goals (1–3 bullets).
+- Describe Typical Communication and Interactions with existing roles.
+- Record where this role is expected to appear in project artifacts (e.g., owner of risk, reviewer of designs, on-call).

--- a/docs/roles-and-personas-checklist.md
+++ b/docs/roles-and-personas-checklist.md
@@ -1,0 +1,26 @@
+# Roles & Personas — Definition and Onboarding Checklist
+
+Purpose: ensure role definitions are complete, actionable, and visible to the team. Use this checklist when adding a new persona or updating responsibilities.
+
+- [ ] Role Summary (1–2 sentence description)
+- [ ] Responsibilities (clear, actionable bullets)
+- [ ] Interaction map (who this role regularly coordinates with)
+- [ ] Decision authority (what decisions this role can make)
+- [ ] Acceptance criteria for deliverables owned by the role
+- [ ] Onboarding notes (access, tools, meetings to attend)
+- [ ] Example artifacts owned or produced by the role (e.g., acceptance criteria, runbook, research report)
+- [ ] Add role to docs/octoacme-roles-and-personas.md and reference from project README or One-pager
+- [ ] Stakeholder review completed (who reviewed and when)
+- [ ] Owner assigned for ongoing maintenance of the role definition
+
+Onboarding checklist for a new person filling the role:
+- [ ] Introductions to PM, PdM, and primary team members
+- [ ] Access granted to required repos, boards, and tools
+- [ ] Walkthrough of current project one-pager and relevant artifacts
+- [ ] Pairing session with role predecessor or subject-matter peer
+- [ ] First-30-day goals documented and shared
+
+Acceptance criteria for role definition changes:
+- Role is aligned with existing process docs and does not contradict responsibilities defined elsewhere
+- Changes improve clarity or close a documented gap
+- Proposed content has been reviewed with stakeholders (if needed) and recorded in the role history


### PR DESCRIPTION
This PR expands our documented roles and personas and adds a checklist to standardize role definitions and onboarding. Improvements address gaps identified in the project management docs around accountability and role interactions.

Changes:
- docs/octoacme-roles-and-personas.md: add Business Analyst, DevOps Engineer, UX Designer, Executive Sponsor, Customer Advocate with responsibilities and interaction patterns.
- docs/roles-and-personas-checklist.md: new checklist to validate role definitions and onboard role-holders.
- docs/octoacme-project-management-overview.md: reference to the expanded personas doc and supporting roles.
- docs/octoacme-execution-and-tracking.md: clarify DevOps and Customer Advocate interactions during execution.

Related issue: refs #5 

reviewer francescodallagata-dedagroup